### PR TITLE
Support for ContactSwitch capability

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Hubitat Tailwind Garage Door Controller",
   "author": "dbadge",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "minimumHEVersion": "2.2.8",
   "dateReleased": "2021-4-25",
   "drivers": [
@@ -11,7 +11,7 @@
       "namespace": "dabtailwind-gd",
       "location": "https://raw.githubusercontent.com/Gelix/HubitatTailwind/main/tailwinddriver-child.groovy",
       "required": true,
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "id": "98a5245c-42fd-4cb2-910b-dd6d83a67d42",
@@ -19,8 +19,8 @@
       "namespace": "dabtailwind-gd",
       "location": "https://raw.githubusercontent.com/Gelix/HubitatTailwind/main/tailwinddriver.groovy",
       "required": true,
-      "version": "1.0.3"
+      "version": "1.0.4"
     }
   ],
-  "releaseNotes": "Official 9.95 firmware compability, incompatible with older BETA firmware."
+  "releaseNotes": "Official 9.95 firmware compability, incompatible with older BETA firmware.\nAdds support for contact switch to child doors"
 }

--- a/tailwinddriver-child.groovy
+++ b/tailwinddriver-child.groovy
@@ -2,10 +2,13 @@ metadata {
     definition (
         name: "Tailwind Garage Door Child Device", 
 		namespace: "dabtailwind-gd", 
-		author: "dbadge"		
+		author: "dbadge",
+        importUrl: "https://raw.githubusercontent.com/Gelix/HubitatTailwind/main/tailwinddriver-child.groovy"
     ) {
         capability "GarageDoorControl"
         capability "Actuator"
+        capability "ContactSensor"
+        capability "Sensor"
         attribute "Status", "string"
         command "open"
         command "close"

--- a/tailwinddriver.groovy
+++ b/tailwinddriver.groovy
@@ -16,7 +16,8 @@ metadata {
     definition (
         name: "Tailwind Garage Door", 
 		namespace: "dabtailwind-gd", 
-		author: "dbadge"		
+		author: "dbadge",
+        importUrl: "https://raw.githubusercontent.com/Gelix/HubitatTailwind/main/tailwinddriver.groovy"
     ) {
         capability "Polling"
         attribute "Status", "string"
@@ -241,6 +242,9 @@ void setChildStatus(dNum, status){
         if(debugEnable) log.debug "Child device ${cName}:${dNum} DOESN'T match real door, update child to match"
         cd.sendEvent(name:"door", value:"${status}")
     }    
+    if (status ==~ /open|closed/ && cd.latestValue('contact') != status) {
+        cd.sendEvent(name:'contact', value:"${status}")
+    }
 }
 
 def getDoorOpenClose(Integer curStatus)


### PR DESCRIPTION
This PR adds support for ContactSensor capability.  Too many of the Hubitat apps do not support DoorControl and GarageDoorControl.  By adding ContactSensor, application is the Notifications app can send notifications with the door is opened or closed.